### PR TITLE
docs: Fix a few typos

### DIFF
--- a/pydiction.py
+++ b/pydiction.py
@@ -149,9 +149,9 @@ def my_import(name):
 def remove_duplicates(seq, keep=()):
     """
 
-    Remove duplicates from a sequence while perserving order.
+    Remove duplicates from a sequence while preserving order.
 
-    The optional tuple argument "keep" can be given to specificy
+    The optional tuple argument "keep" can be given to specify
     each string you don't want to be removed as a duplicate.
     """
     seq2 = []


### PR DESCRIPTION
There are small typos in:
- pydiction.py

Fixes:
- Should read `specify` rather than `specificy`.
- Should read `preserving` rather than `perserving`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md